### PR TITLE
Fix Windows label parsing

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -261,6 +261,9 @@ export class AsmParser extends AsmRegex implements IAsmParser {
     }
 
     private shouldSkipCommentOnlyLine(filters: ParseFiltersAndOutputOptions, line: string): boolean {
+        if (this.labelDef.test(line)) {
+            return false;
+        }
         return Boolean(
             filters.commentOnly &&
                 ((this.commentOnly.test(line) && !this.parsingState.inNvccCode) ||

--- a/test/asm-parser-tests.ts
+++ b/test/asm-parser-tests.ts
@@ -43,6 +43,17 @@ describe('AsmParser tests', () => {
     });
 });
 
+describe('AsmParser comment filtering', () => {
+    const parser = new AsmParser();
+    it('should keep label lines starting with @ when filtering comments', () => {
+        const input = '@cube@4:\n    ret';
+        const result = parser.processAsm(input, {commentOnly: true});
+        const lines = result.asm.map(line => line.text);
+        expect(lines[0]).toBe('@cube@4:');
+        expect(lines[1]).toBe('    ret');
+    });
+});
+
 describe('PTXAsmParser tests', () => {
     const parser = new PTXAsmParser();
 


### PR DESCRIPTION
 ensure comment filtering doesn't drop label definitions that begin with `@`
 add regression test for comment filtering

 `npm run lint`
 `npm run ts-check`
 `npm run test-min`
 `npm run check-frontend-imports`
 
